### PR TITLE
Fix/binance multiple currency bug

### DIFF
--- a/crates/portfolio/src/manager.rs
+++ b/crates/portfolio/src/manager.rs
@@ -26,7 +26,7 @@ use nautilus_model::{
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
     position::Position,
-    types::{AccountBalance, Money, Currency},
+    types::{AccountBalance, Currency, Money},
 };
 use rust_decimal::{Decimal, prelude::ToPrimitive};
 /// Manages account balance updates and calculations for portfolio management.

--- a/crates/portfolio/src/manager.rs
+++ b/crates/portfolio/src/manager.rs
@@ -15,7 +15,7 @@
 
 //! Provides account management functionality.
 
-use std::{cell::RefCell, fmt::Debug, rc::Rc};
+use std::{cell::RefCell, fmt::Debug, rc::Rc, collections::HashMap};
 
 use nautilus_common::{cache::Cache, clock::Clock};
 use nautilus_core::{UUID4, UnixNanos};
@@ -26,7 +26,7 @@ use nautilus_model::{
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
     position::Position,
-    types::{AccountBalance, Money},
+    types::{AccountBalance, Money, Currency},
 };
 use rust_decimal::{Decimal, prelude::ToPrimitive};
 /// Manages account balance updates and calculations for portfolio management.
@@ -286,7 +286,7 @@ impl AccountsManager {
             ));
         }
 
-        let mut total_locked = 0.0;
+        let mut total_locked: Vec<Money> = vec![];
         let mut base_xrate: Option<f64> = None;
 
         let mut currency = instrument.settlement_currency();
@@ -322,8 +322,7 @@ impl AccountsManager {
                     price?,
                     None,
                 )
-                .unwrap()
-                .as_f64();
+                .unwrap();
 
             if let Some(base_curr) = account.base_currency() {
                 if base_xrate.is_none() {
@@ -336,25 +335,33 @@ impl AccountsManager {
                 }
 
                 if let Some(xrate) = base_xrate {
-                    locked *= xrate;
+                    locked = Money::new(locked.as_f64() * xrate, currency);
                 } else {
                     // TODO: Revisit error handling
                     panic!("Cannot calculate base xrate");
                 }
             }
 
-            total_locked += locked;
+            total_locked.push(locked);
         }
 
-        let balance_locked = Money::new(total_locked.to_f64()?, currency);
-
-        if let Some(balance) = account.balances.get_mut(&instrument.quote_currency()) {
-            balance.locked = balance_locked;
-            let currency = balance.currency;
-            account.recalculate_balance(currency);
+        let mut aggregated_locked: HashMap<Currency, Money> = HashMap::new();
+        for locked in total_locked.into_iter() {
+            aggregated_locked
+                .entry(locked.currency)
+                .and_modify(|total| *total += locked)
+                .or_insert(locked);
         }
 
-        log::info!("{} balance_locked={balance_locked}", instrument.id());
+        for (_, balance_locked) in aggregated_locked {
+            if let Some(balance) = account.balances.get_mut(&balance_locked.currency) {
+                balance.locked = balance_locked;
+                let currency = balance.currency;
+                account.recalculate_balance(currency);
+            }
+
+            log::info!("{} balance_locked={balance_locked}", instrument.id());
+        }
 
         Some((
             account.clone(),

--- a/crates/portfolio/src/manager.rs
+++ b/crates/portfolio/src/manager.rs
@@ -286,7 +286,7 @@ impl AccountsManager {
             ));
         }
 
-        let mut total_locked: Vec<Money> = vec![];
+        let mut total_locked: HashMap<Currency, Money> = HashMap::new();
         let mut base_xrate: Option<f64> = None;
 
         let mut currency = instrument.settlement_currency();
@@ -342,18 +342,13 @@ impl AccountsManager {
                 }
             }
 
-            total_locked.push(locked);
-        }
-
-        let mut aggregated_locked: HashMap<Currency, Money> = HashMap::new();
-        for locked in total_locked.into_iter() {
-            aggregated_locked
+            total_locked
                 .entry(locked.currency)
                 .and_modify(|total| *total += locked)
                 .or_insert(locked);
         }
 
-        for (_, balance_locked) in aggregated_locked {
+        for (_, balance_locked) in total_locked {
             if let Some(balance) = account.balances.get_mut(&balance_locked.currency) {
                 balance.locked = balance_locked;
                 let currency = balance.currency;

--- a/crates/portfolio/src/manager.rs
+++ b/crates/portfolio/src/manager.rs
@@ -15,7 +15,7 @@
 
 //! Provides account management functionality.
 
-use std::{cell::RefCell, fmt::Debug, rc::Rc, collections::HashMap};
+use std::{cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc};
 
 use nautilus_common::{cache::Cache, clock::Clock};
 use nautilus_core::{UUID4, UnixNanos};


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

There is still a problem: when multiple open orders in different directions exist simultaneously, `currency` cannot reflect the currency types of the locked balance currency for all orders. I have submitted a version for review—please check it. I constructed a dict type to aggregate balance for different currencies simultaneously and freeze them separately.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
